### PR TITLE
Updates dependancies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
-{deps, [ {supervisor3, "1.1.11"}
-       , {kafka_protocol, "2.3.6"}
+{deps, [ {supervisor3, "1.1.15"}
+       , {kafka_protocol, "2.5.0"}
        ]}.
 {edoc_opts, [{preprocess, true}, {macros, [{build_brod_cli, true}]}]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.


### PR DESCRIPTION
We need to update FCS elixir to 1.12 to update to bullseye deb - this means we need to update a few other dependancies.